### PR TITLE
Improve cyberpunk calculator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # ScCalc
-Scientefic Calculator App
+
+ScCalc is a cyberpunk‑styled scientific calculator powered by **React 18**, **Material&nbsp;UI**, and **Math.js**. Open `index.html` in your browser to try it out.
+
+### Features
+
+- Modern dark theme with neon accents
+- Basic arithmetic and exponentiation
+- Trigonometric and inverse trigonometric functions
+- Logarithms (`log10` and natural `ln`)
+- Square root and absolute value
+- Constants `pi` and `e`
+- Factorial `!`
+- Parentheses for grouping

--- a/index.html
+++ b/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ScCalc - Scientific Calculator</title>
+    <!-- MUI + emotion for styling -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&display=swap" />
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Orbitron', Arial, sans-serif;
+            background: radial-gradient(#051937,#000000);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: #14ffec;
+        }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <!-- React and ReactDOM -->
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="https://unpkg.com/mathjs@11/lib/browser/math.js"></script>
+    <script src="https://unpkg.com/@emotion/react@latest/umd/emotion-react.umd.min.js"></script>
+    <script src="https://unpkg.com/@emotion/styled@latest/umd/emotion-styled.umd.min.js"></script>
+    <script src="https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js"></script>
+    
+    <script type="text/babel">
+        const { useState } = React;
+        const {
+            Box,
+            Button,
+            CssBaseline,
+            Grid,
+            ThemeProvider,
+            Typography,
+            createTheme,
+        } = MaterialUI;
+
+        const buttons = [
+            '7','8','9','/','sin','cos',
+            '4','5','6','*','tan','log',
+            '1','2','3','-','ln','sqrt',
+            '0','.','^','+','(',')',
+            'pi','e','asin','acos','atan','log10',
+            'abs','!','DEL','CLR','=',''
+        ];
+
+        function ScCalc() {
+            const [expr, setExpr] = useState('');
+
+            const handleClick = (val) => {
+                if (val === 'DEL') {
+                    setExpr(expr.slice(0, -1));
+                } else if (val === 'CLR') {
+                    setExpr('');
+                } else if (val === '=') {
+                    try {
+                        const res = math.evaluate(expr);
+                        setExpr(String(res));
+                    } catch (e) {
+                        setExpr('Error');
+                    }
+                } else if (['pi','e'].includes(val)) {
+                    setExpr(expr + val);
+                } else if (val === '!') {
+                    setExpr(expr + '!');
+                } else if (['sin','cos','tan','asin','acos','atan','sqrt','abs','log','ln','log10'].includes(val)) {
+                    const map = { ln: 'log', log: 'log10' };
+                    const func = map[val] || val;
+                    setExpr(expr + func + '(');
+                } else if (val) {
+                    setExpr(expr + val);
+                }
+            };
+
+            const theme = createTheme({
+                palette: {
+                    mode: 'dark',
+                    primary: { main: '#14ffec' },
+                    background: { default: '#00040d', paper: '#111' },
+                },
+                typography: { fontFamily: 'Orbitron, Arial, sans-serif' },
+            });
+
+            return (
+                <ThemeProvider theme={theme}>
+                    <CssBaseline />
+                    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', p: 2 }}>
+                        <Box sx={{ width: 380, p: 2, borderRadius: 2, boxShadow: 5, bgcolor: 'background.paper' }}>
+                            <Typography variant="h4" align="center" gutterBottom>ScCalc</Typography>
+                            <Box sx={{ bgcolor: '#000', color: '#14ffec', borderRadius: 1, p: 1, mb: 2, minHeight: '48px', fontFamily: 'monospace' }}>{expr || '0'}</Box>
+                            <Grid container spacing={1}>
+                                {buttons.map((b, i) => (
+                                    <Grid item xs={2} key={i}>
+                                        <Button variant="contained" color="primary" fullWidth onClick={() => handleClick(b)}>{b}</Button>
+                                    </Grid>
+                                ))}
+                            </Grid>
+                        </Box>
+                    </Box>
+                </ThemeProvider>
+            );
+        }
+
+        ReactDOM.createRoot(document.getElementById('root')).render(<ScCalc />);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle calculator with neon cyberpunk theme
- add Material UI theme via CDN
- support more scientific functions like asin, acos, atan, log10, abs and factorial
- document features in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861998ef5f8832ba1b62676b81afc8c